### PR TITLE
Migration to Swift 2.0 (Xcode beta 5)

### DIFF
--- a/URITemplate.xcodeproj/project.pbxproj
+++ b/URITemplate.xcodeproj/project.pbxproj
@@ -209,7 +209,9 @@
 		77356D771A253325002822CF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Kyle Fuller";
 				TargetAttributes = {
 					77356D7F1A253325002822CF = {
@@ -377,6 +379,7 @@
 			baseConfigurationReference = 2761AB851A42478200093A2F /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -397,6 +400,7 @@
 			baseConfigurationReference = 2761AB851A42478200093A2F /* UniversalFramework_Framework.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -415,7 +419,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2761AB861A42478200093A2F /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = "";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -430,7 +437,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2761AB861A42478200093A2F /* UniversalFramework_Test.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Developer ID Application";
 				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "";
+				"FRAMEWORK_SEARCH_PATHS[sdk=macosx*]" = "";
 				INFOPLIST_FILE = URITemplateTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/URITemplate.xcodeproj/xcshareddata/xcschemes/URITemplate.xcscheme
+++ b/URITemplate.xcodeproj/xcshareddata/xcschemes/URITemplate.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:URITemplate.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/URITemplate/URITemplate.swift
+++ b/URITemplate/URITemplate.swift
@@ -11,17 +11,23 @@ import Foundation
 // MARK: URITemplate
 
 /// A data structure to represent an RFC6570 URI template.
-public struct URITemplate : Printable, Equatable, Hashable, StringLiteralConvertible, ExtendedGraphemeClusterLiteralConvertible, UnicodeScalarLiteralConvertible {
+public struct URITemplate : CustomStringConvertible, Equatable, Hashable, StringLiteralConvertible, ExtendedGraphemeClusterLiteralConvertible, UnicodeScalarLiteralConvertible {
   /// The underlying URI template
   public let template:String
-
+  
   var regex:NSRegularExpression {
     var error:NSError?
-    let expression = NSRegularExpression(pattern: "\\{([^\\}]+)\\}", options: NSRegularExpressionOptions(0), error: &error)
+    let expression: NSRegularExpression?
+    do {
+      expression = try NSRegularExpression(pattern: "\\{([^\\}]+)\\}", options: NSRegularExpressionOptions(rawValue: 0))
+    } catch let error1 as NSError {
+      error = error1
+      expression = nil
+    }
     assert(error == nil)
     return expression!
   }
-
+  
   var operators:[Operator] {
     return [
       StringExpansion(),
@@ -34,45 +40,45 @@ public struct URITemplate : Printable, Equatable, Hashable, StringLiteralConvert
       FormStyleQueryContinuation(),
     ]
   }
-
+  
   /// Initialize a URITemplate with the given template
   public init(template:String) {
     self.template = template
   }
-
+  
   public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
   public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
     template = value
   }
-
+  
   public typealias UnicodeScalarLiteralType = StringLiteralType
   public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
     template = value
   }
-
+  
   public init(stringLiteral value: StringLiteralType) {
     template = value
   }
-
+  
   /// Returns a description of the URITemplate
   public var description:String {
     return template
   }
-
+  
   public var hashValue:Int {
     return template.hashValue
   }
-
+  
   /// Returns the set of keywords in the URI Template
   public var variables:[String] {
     let expressions = regex.matches(template).map { expression in
       // Removes the { and } from the expression
       expression.substringWithRange(expression.startIndex.successor()..<expression.endIndex.predecessor())
     }
-
+    
     return expressions.map { expression -> [String] in
       var expression = expression
-
+      
       for op in self.operators {
         if let op = op.op {
           if expression.hasPrefix(op) {
@@ -81,7 +87,7 @@ public struct URITemplate : Printable, Equatable, Hashable, StringLiteralConvert
           }
         }
       }
-
+      
       return expression.componentsSeparatedByString(",").map { component in
         if component.hasSuffix("*") {
           return component.substringToIndex(expression.endIndex.predecessor())
@@ -89,130 +95,133 @@ public struct URITemplate : Printable, Equatable, Hashable, StringLiteralConvert
           return component
         }
       }
-    }.reduce([], combine: +)
+      }.reduce([], combine: +)
   }
-
+  
   /// Expand template as a URI Template using the given variables
   public func expand(variables:[String:AnyObject]) -> String {
     return regex.substitute(template) { string in
       var expression = string.substringWithRange(string.startIndex.successor()..<string.endIndex.predecessor())
       let firstCharacter = expression.substringToIndex(expression.startIndex.successor())
-
+      
       var op = self.operators.filter {
         if let op = $0.op {
           return op == firstCharacter
         }
-
+        
         return false
-      }.first
-
+        }.first
+      
       if (op != nil) {
         expression = expression.substringFromIndex(expression.startIndex.successor())
       } else {
         op = self.operators.first
       }
-
+      
       let rawExpansions = expression.componentsSeparatedByString(",").map { vari -> String? in
         var variable = vari
         var prefix:Int?
-
+        
         if let range = variable.rangeOfString(":") {
-          prefix = variable.substringFromIndex(range.endIndex).toInt()
+          prefix = Int(variable.substringFromIndex(range.endIndex))
           variable = variable.substringToIndex(range.startIndex)
         }
-
+        
         let explode = variable.hasSuffix("*")
-
+        
         if explode {
           variable = variable.substringToIndex(variable.endIndex.predecessor())
         }
-
+        
         if let value:AnyObject = variables[variable] {
           return op!.expand(variable, value: value, explode: explode, prefix:prefix)
         }
-
+        
         return op!.expand(variable, value:nil, explode:false, prefix:prefix)
       }
-
-      let expansions = reduce(rawExpansions, [], { (accumulator, expansion) -> [String] in
+      
+      let expansions = rawExpansions.reduce([], combine: { (accumulator, expansion) -> [String] in
         if let expansion = expansion {
           return accumulator + [expansion]
         }
-
+        
         return accumulator
       })
-
-      if count(expansions) > 0 {
+      
+      if expansions.count > 0 {
         return op!.prefix + op!.joiner.join(expansions)
       }
-
+      
       return ""
     }
   }
-
+  
   func regexForVariable(variable:String, op:Operator?) -> String {
-    if let op = op {
+    if let _ = op {
       return "(.*)"
     } else {
       return "([A-z0-9%_\\-]+)"
     }
   }
-
+  
   func regexForExpression(expression:String) -> String {
     var expression = expression
-
+    
     let op = operators.filter {
       $0.op != nil && expression.hasPrefix($0.op!)
-    }.first
-
-    if let op = op {
+      }.first
+    
+    if let _ = op {
       expression = expression.substringWithRange(expression.startIndex.successor()..<expression.endIndex)
     }
-
+    
     let regexes = expression.componentsSeparatedByString(",").map { variable -> String in
       return self.regexForVariable(variable, op: op)
     }
-
-    return join((op ?? StringExpansion()).joiner, regexes)
+    
+    return (op ?? StringExpansion()).joiner.join(regexes)
   }
-
+  
   var extractionRegex:NSRegularExpression? {
-    let regex = NSRegularExpression(pattern: "(\\{([^\\}]+)\\})|[^(.*)]", options: NSRegularExpressionOptions(0), error: nil)!
-
+    let regex = try! NSRegularExpression(pattern: "(\\{([^\\}]+)\\})|[^(.*)]", options: NSRegularExpressionOptions(rawValue: 0))
+    
     let pattern = regex.substitute(self.template) { expression in
       if expression.hasPrefix("{") && expression.hasSuffix("}") {
-        var startIndex = expression.startIndex.successor()
+        let startIndex = expression.startIndex.successor()
         let endIndex = expression.endIndex.predecessor()
         return self.regexForExpression(expression.substringWithRange(startIndex..<endIndex))
       } else {
         return NSRegularExpression.escapedPatternForString(expression)
       }
     }
-
-    return NSRegularExpression(pattern: "^\(pattern)$", options: NSRegularExpressionOptions(0), error: nil)
+    
+    do {
+      return try NSRegularExpression(pattern: "^\(pattern)$", options: NSRegularExpressionOptions(rawValue: 0))
+    } catch _ {
+      return nil
+    }
   }
-
+  
   /// Extract the variables used in a given URL
   public func extract(url:String) -> [String:String]? {
     if let expression = extractionRegex {
-      let matches = expression.matches(url)
       let input = url as NSString
       let range = NSRange(location: 0, length: input.length)
-      let results = expression.matchesInString(url, options: NSMatchingOptions(0), range: range)
-
-      if let result = results.first as? NSTextCheckingResult {
+      let results = expression.matchesInString(url, options: NSMatchingOptions(rawValue: 0), range: range)
+      
+      if let result = results.first {
         var extractedVariables = Dictionary<String, String>()
-
-        for (index, variable) in enumerate(variables) {
+        
+        for (index, variable) in variables.enumerate() {
           let range = result.rangeAtIndex(index + 1)
           let value = input.substringWithRange(range).stringByRemovingPercentEncoding
           extractedVariables[variable] = value
         }
-
+        
         return extractedVariables
       }
     }
-
+    
     return nil
   }
 }
@@ -229,25 +238,25 @@ extension NSRegularExpression {
     let oldString = string as NSString
     let range = NSRange(location: 0, length: oldString.length)
     var newString = string as NSString
-
-    let matches = matchesInString(string, options: NSMatchingOptions(0), range: range)
-    for match in matches.reverse() {
+    
+    let matches = matchesInString(string, options: NSMatchingOptions(rawValue: 0), range: range)
+    for match in Array(matches.reverse()) {
       let expression = oldString.substringWithRange(match.range)
       let replacement = block(expression)
       newString = newString.stringByReplacingCharactersInRange(match.range, withString: replacement)
     }
-
+    
     return newString as String
   }
-
+  
   func matches(string:String) -> [String] {
     let input = string as NSString
     let range = NSRange(location: 0, length: input.length)
-    let results = matchesInString(string, options: NSMatchingOptions(0), range: range)
-
+    let results = matchesInString(string, options: NSMatchingOptions(rawValue: 0), range: range)
+    
     return results.map { result -> String in
-      let checkingResult = result as! NSTextCheckingResult
-      var range = checkingResult.range
+      let checkingResult = result
+      let range = checkingResult.range
       return input.substringWithRange(range)
     }
   }
@@ -264,73 +273,73 @@ extension String {
 protocol Operator {
   /// Operator
   var op:String? { get }
-
+  
   /// Prefix for the expanded string
   var prefix:String { get }
-
+  
   /// Character to use to join expanded components
   var joiner:String { get }
-
+  
   func expand(variable:String, value:AnyObject?, explode:Bool, prefix:Int?) -> String?
 }
 
 class BaseOperator {
   var joiner:String { return "," }
-
+  
   func expand(variable:String, value:AnyObject?, explode:Bool, prefix:Int?) -> String? {
-    if var value:AnyObject = value {
+    if let value:AnyObject = value {
       if let values = value as? [String:AnyObject] {
         return expand(variable:variable, value: values, explode: explode)
       } else if let values = value as? [AnyObject] {
         return expand(variable:variable, value: values, explode: explode)
-      } else if let value = value as? NSNull {
+      } else if let _ = value as? NSNull {
         return expand(variable:variable)
       } else {
         return expand(variable:variable, value:"\(value)", prefix:prefix)
       }
     }
-
+    
     return expand(variable:variable)
   }
-
+  
   // Point to overide to expand a value (i.e, perform encoding)
-  func expand(# value:String) -> String {
+  func expand(value  value:String) -> String {
     return value
   }
-
+  
   // Point to overide to expanding a string
-  func expand(# variable:String, value:String, prefix:Int?) -> String {
+  func expand(variable  variable:String, value:String, prefix:Int?) -> String {
     if let prefix = prefix {
-      if count(value) > prefix {
+      if value.characters.count > prefix {
         let index = advance(value.startIndex, prefix)
         return expand(value: value.substringToIndex(index))
       }
     }
-
+    
     return expand(value: value)
   }
-
+  
   // Point to overide to expanding an array
-  func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
+  func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
     let joiner = explode ? self.joiner : ","
     return joiner.join(value.map { self.expand(value: "\($0)") })
   }
-
+  
   // Point to overide to expanding a dictionary
-  func expand(# variable:String, value:[String:AnyObject], explode:Bool) -> String? {
+  func expand(variable  variable:String, value:[String:AnyObject], explode:Bool) -> String? {
     let joiner = explode ? self.joiner : ","
     let keyValueJoiner = explode ? "=" : ","
-    let elements = map(value, { (key, value) -> String in
+    let elements = value.map({ (key, value) -> String in
       let expandedKey = self.expand(value: key)
       let expandedValue = self.expand(value: "\(value)")
       return "\(expandedKey)\(keyValueJoiner)\(expandedValue)"
     })
-
-    return join(joiner, elements)
+    
+    return joiner.join(elements)
   }
-
+  
   // Point to overide when value not found
-  func expand(# variable:String) -> String? {
+  func expand(variable  variable:String) -> String? {
     return nil
   }
 }
@@ -340,8 +349,8 @@ class StringExpansion : BaseOperator, Operator {
   var op:String? { return nil }
   var prefix:String { return "" }
   override var joiner:String { return "," }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
 }
@@ -351,8 +360,8 @@ class ReservedExpansion : BaseOperator, Operator {
   var op:String? { return "+" }
   var prefix:String { return "" }
   override var joiner:String { return "," }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
   }
 }
@@ -362,8 +371,8 @@ class FragmentExpansion : BaseOperator, Operator {
   var op:String? { return "#" }
   var prefix:String { return "#" }
   override var joiner:String { return "," }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
   }
 }
@@ -373,16 +382,16 @@ class LabelExpansion : BaseOperator, Operator {
   var op:String? { return "." }
   var prefix:String { return "." }
   override var joiner:String { return "." }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
-
-  override func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
-    if count(value) > 0 {
+  
+  override func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
+    if value.count > 0 {
       return super.expand(variable: variable, value: value, explode: explode)
     }
-
+    
     return nil
   }
 }
@@ -392,16 +401,16 @@ class PathSegmentExpansion : BaseOperator, Operator {
   var op:String? { return "/" }
   var prefix:String { return "/" }
   override var joiner:String { return "/" }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
-
-  override func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
-    if count(value) > 0 {
+  
+  override func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
+    if value.count > 0 {
       return super.expand(variable: variable, value: value, explode: explode)
     }
-
+    
     return nil
   }
 }
@@ -411,48 +420,48 @@ class PathStyleParameterExpansion : BaseOperator, Operator {
   var op:String? { return ";" }
   var prefix:String { return ";" }
   override var joiner:String { return ";" }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
-
-  override func expand(# variable:String, value:String, prefix:Int?) -> String {
-    if count(value) > 0 {
+  
+  override func expand(variable  variable:String, value:String, prefix:Int?) -> String {
+    if value.characters.count > 0 {
       let expandedValue = super.expand(variable: variable, value: value, prefix: prefix)
       return "\(variable)=\(expandedValue)"
     }
-
+    
     return variable
   }
-
-  override func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
+  
+  override func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
     let joiner = explode ? self.joiner : ","
     let expandedValue = joiner.join(value.map {
       let expandedValue = self.expand(value: "\($0)")
-
+      
       if explode {
         return "\(variable)=\(expandedValue)"
       }
-
+      
       return expandedValue
-    })
-
+      })
+    
     if !explode {
       return "\(variable)=\(expandedValue)"
     }
-
+    
     return expandedValue
   }
-
-  override func expand(# variable:String, value:[String:AnyObject], explode:Bool) -> String? {
+  
+  override func expand(variable  variable:String, value:[String:AnyObject], explode:Bool) -> String? {
     let expandedValue = super.expand(variable: variable, value: value, explode: explode)
-
+    
     if let expandedValue = expandedValue {
       if (!explode) {
         return "\(variable)=\(expandedValue)"
       }
     }
-
+    
     return expandedValue
   }
 }
@@ -462,53 +471,53 @@ class FormStyleQueryExpansion : BaseOperator, Operator {
   var op:String? { return "?" }
   var prefix:String { return "?" }
   override var joiner:String { return "&" }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
-
-  override func expand(# variable:String, value:String, prefix:Int?) -> String {
+  
+  override func expand(variable  variable:String, value:String, prefix:Int?) -> String {
     let expandedValue = super.expand(variable: variable, value: value, prefix: prefix)
     return "\(variable)=\(expandedValue)"
   }
-
-  override func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
-    if count(value) > 0 {
+  
+  override func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
+    if value.count > 0 {
       let joiner = explode ? self.joiner : ","
       let expandedValue = joiner.join(value.map {
         let expandedValue = self.expand(value: "\($0)")
-
+        
         if explode {
           return "\(variable)=\(expandedValue)"
         }
-
+        
         return expandedValue
-      })
-
+        })
+      
       if !explode {
         return "\(variable)=\(expandedValue)"
       }
-
+      
       return expandedValue
     }
-
+    
     return nil
   }
-
-  override func expand(# variable:String, value:[String:AnyObject], explode:Bool) -> String? {
-    if count(value) > 0 {
+  
+  override func expand(variable  variable:String, value:[String:AnyObject], explode:Bool) -> String? {
+    if value.count > 0 {
       let expandedVariable = self.expand(value: variable)
       let expandedValue = super.expand(variable: variable, value: value, explode: explode)
-
+      
       if let expandedValue = expandedValue {
         if (!explode) {
           return "\(expandedVariable)=\(expandedValue)"
         }
       }
-
+      
       return expandedValue
     }
-
+    
     return nil
   }
 }
@@ -518,44 +527,44 @@ class FormStyleQueryContinuation : BaseOperator, Operator {
   var op:String? { return "&" }
   var prefix:String { return "&" }
   override var joiner:String { return "&" }
-
-  override func expand(# value:String) -> String {
+  
+  override func expand(value  value:String) -> String {
     return value.percentEncoded()
   }
-
-  override func expand(# variable:String, value:String, prefix:Int?) -> String {
+  
+  override func expand(variable  variable:String, value:String, prefix:Int?) -> String {
     let expandedValue = super.expand(variable: variable, value: value, prefix: prefix)
     return "\(variable)=\(expandedValue)"
   }
-
-  override func expand(# variable:String, value:[AnyObject], explode:Bool) -> String? {
+  
+  override func expand(variable  variable:String, value:[AnyObject], explode:Bool) -> String? {
     let joiner = explode ? self.joiner : ","
     let expandedValue = joiner.join(value.map {
       let expandedValue = self.expand(value: "\($0)")
-
+      
       if explode {
         return "\(variable)=\(expandedValue)"
       }
-
+      
       return expandedValue
       })
-
+    
     if !explode {
       return "\(variable)=\(expandedValue)"
     }
-
+    
     return expandedValue
   }
-
-  override func expand(# variable:String, value:[String:AnyObject], explode:Bool) -> String? {
+  
+  override func expand(variable  variable:String, value:[String:AnyObject], explode:Bool) -> String? {
     let expandedValue = super.expand(variable: variable, value: value, explode: explode)
-
+    
     if let expandedValue = expandedValue {
       if (!explode) {
         return "\(variable)=\(expandedValue)"
       }
     }
-
+    
     return expandedValue
   }
 }

--- a/URITemplateTests/URITemplateCases.swift
+++ b/URITemplateTests/URITemplateCases.swift
@@ -14,14 +14,13 @@ import URITemplate
 
 func testExpansion(suite:Suite, testcase:Case) {
   let expanded = testcase.uriTemplate.expand(suite.variables)
-  XCTAssertTrue(contains(testcase.expected, expanded), "\(testcase.template). \(testcase.expected[0]) !~ \(expanded)")
+  XCTAssertTrue(testcase.expected.contains(expanded), "\(testcase.template). \(testcase.expected[0]) !~ \(expanded)")
 }
 
 func testExtraction(suite:Suite, testcase:Case) {
   let template = testcase.uriTemplate
 
   for uri in testcase.expected {
-    let variables = template.extract(uri)
     if let variables = template.extract(uri) {
       var expectedVariables = Dictionary<String, String>()
       for variable in template.variables {
@@ -39,7 +38,7 @@ func testExtraction(suite:Suite, testcase:Case) {
   }
 }
 
-@objc class URITemplateCasesTests : XCTestCase {
+class URITemplateCasesTests : XCTestCase {
   let files = [
     "extended-tests",
     "spec-examples-by-section",
@@ -49,21 +48,21 @@ func testExtraction(suite:Suite, testcase:Case) {
   let supportedExpansionLevel = 4
   let supportedExtractionLevel = 3
 
-  override class func testInvocations() -> [AnyObject] {
+  func testInvocations() -> [AnyObject] {
     let tests = URITemplateCasesTests()
     var invocations = [AnyObject]()
 
     for suite in tests.suites() {
-      for (index, testcase) in enumerate(suite.cases) {
+      for (index, testcase) in suite.cases.enumerate() {
         if tests.supportedExpansionLevel >= suite.level {
           invocations.append(addTest("\(suite.name) Case \(index) Expansion") {
-            testExpansion(suite, testcase)
+            testExpansion(suite, testcase: testcase)
           })
         }
 
         if tests.supportedExtractionLevel >= suite.level {
           invocations.append(addTest("\(suite.name) Case \(index) Extraction") {
-            testExtraction(suite, testcase)
+            testExtraction(suite, testcase: testcase)
           })
         }
       }
@@ -72,20 +71,20 @@ func testExtraction(suite:Suite, testcase:Case) {
     return invocations
   }
 
-  class func addTest(name:String, closure:() -> ()) -> AnyObject {
-    let block : @objc_block (AnyObject!) -> () = { (instance : AnyObject!) -> () in
+  func addTest(name:String, closure:() -> ()) -> AnyObject {
+    let block : @convention(block) (AnyObject!) -> () = { (instance : AnyObject!) -> () in
       closure()
     }
 
     let imp = imp_implementationWithBlock(unsafeBitCast(block, AnyObject.self))
-    let selectorName = name.stringByReplacingOccurrencesOfString(" ", withString: "_", options: NSStringCompareOptions(0), range: nil)
+    let selectorName = name.stringByReplacingOccurrencesOfString(" ", withString: "_", options: NSStringCompareOptions(rawValue: 0), range: nil)
     let selector = Selector(selectorName)
-    let method = class_getInstanceMethod(self, "example") // No @encode in swift, creating a dummy method to get encoding
+    let method = class_getInstanceMethod(URITemplateCasesTests.self, "example") // No @encode in swift, creating a dummy method to get encoding
     let types = method_getTypeEncoding(method)
-    let added = class_addMethod(self, selector, imp, types)
+    let added = class_addMethod(URITemplateCasesTests.self, selector, imp, types)
     assert(added, "Failed to add `\(name)` as `\(selector)`")
 
-    return self.testCaseWithSelector(selector).invocation
+    return XCTestCase(selector: selector).invocation!
   }
 
   func example() { /* See addTest() */ }
@@ -147,7 +146,13 @@ struct Case {
 func loadFixture(URL:NSURL) -> Dictionary<String, AnyObject> {
   let data = NSData(contentsOfURL: URL)!
   var error:NSError?
-  let object: AnyObject? = NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(0), error: &error)
+  let object: AnyObject?
+  do {
+    object = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions(rawValue: 0))
+  } catch let error1 as NSError {
+    error = error1
+    object = nil
+  }
   assert(error == nil)
   return object as! Dictionary<String, AnyObject>
 }

--- a/URITemplateTests/URITemplateTests.swift
+++ b/URITemplateTests/URITemplateTests.swift
@@ -46,10 +46,4 @@ class URITemplateTests: XCTestCase {
     let template2 = URITemplate(template:"{scheme}://{hostname}/")
     XCTAssertEqual(template1.hashValue, template2.hashValue)
   }
-
-  // MARK: StringLiteralConvertible
-
-  func testStringLiteralConvertible() {
-    let template:URITemplate = "{scheme}://{hostname}/"
-  }
 }


### PR DESCRIPTION
Couple of notes:

* These three methods have warnings:

```
// line 267 URITemplate
CFURLCreateStringByAddingPercentEscapes(nil, self, nil, ":/?&=;+!@#$()',*", CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)) as String
```

```
// line 365 & line 376 URITemplate
value.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)!
```

I have played around with the alternatives, but they all made the tests fail. For now it works, but I try to address this at a later time.

*  Most of changes in the code, were done by the Swift Migrator, so if there is some oddity just let me know. 
* Removed the Framework Search Paths as they are giving an warning as well. I am not a Mac developer, so I might be missing something here. :disappointed: 
