### PR TITLE
Migrate away from deprecated percent encoding mechanism.

### DIFF
--- a/URITemplate/URITemplate.swift
+++ b/URITemplate/URITemplate.swift
@@ -259,7 +259,8 @@ extension NSRegularExpression {
 
 extension String {
   func percentEncoded() -> String {
-    return CFURLCreateStringByAddingPercentEscapes(nil, self, nil, ":/?&=;+!@#$()',*", CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding)) as String
+    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*").invertedSet
+    return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
   }
 }
 


### PR DESCRIPTION
This addresses a warning I was receiving when using Mockingjay:

`Mockingjay/URITemplate/URITemplate/URITemplate.swift:262:12: 'CFURLCreateStringByAddingPercentEscapes' was deprecated in iOS 9.0: Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).`