### PR TITLE
Disable automatically building tests for framework target

### DIFF
--- a/URITemplate.xcodeproj/xcshareddata/xcschemes/URITemplate.xcscheme
+++ b/URITemplate.xcodeproj/xcshareddata/xcschemes/URITemplate.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "77356D8A1A253325002822CF"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -66,11 +66,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -88,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Building URITemplate via Carthage (v0.9.4) will fail right now, complaining about code signing the unit testing bundle:

```
$ carthage update --platform iOS
*** Fetching URITemplate.swift
*** Checking out URITemplate.swift at "4b0deda5c83b76144c2d98a596f6389af3d1f23f"
*** xcodebuild output can be found in /var/folders/4x/k22fcvxj09q33bnxlpc1ngv00000gn/T/carthage-xcodebuild.WAnD6S.log
*** Building scheme "URITemplate" in URITemplate.xcodeproj
** BUILD FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
CodeSign error: code signing is required for product type 'Unit Test Bundle' in SDK 'iOS 9.1'
A shell task failed with exit code 65:
** BUILD FAILED **


The following build commands failed:
	Check dependencies
(1 failure)
```

This side-steps the issue by changing the scheme to not automatically build the test target when building the framework target.

