### PR TITLE
fixed crash when using list* notation.

### DIFF
--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -87,7 +87,7 @@ public struct URITemplate : CustomStringConvertible, Equatable, Hashable, String
 
       return expression.componentsSeparatedByString(",").map { component in
         if component.hasSuffix("*") {
-          return component.substringToIndex(expression.endIndex.predecessor())
+          return component.substringToIndex(component.endIndex.predecessor())
         } else {
           return component
         }

--- a/Tests/URITemplateVariablesTests.swift
+++ b/Tests/URITemplateVariablesTests.swift
@@ -62,4 +62,9 @@ class URITemplateVariablesTests : XCTestCase {
     let template = URITemplate(template:"{/list*}")
     XCTAssertEqual(template.variables, ["list"])
   }
+	
+	func testMixedQueryParameterVariables() {
+		let template = URITemplate(template:"{scheme}://{hostname}/endpoint.json{?query,list*}")
+		XCTAssert(template.variables.contains("hostname"))
+	}
 }


### PR DESCRIPTION
Looks like the expression was using the incorrect variable.