### PR TITLE
Fixed incorrect expansion of whitespace for URL query parameters.

### DIFF
--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -259,7 +259,7 @@ extension NSRegularExpression {
 
 extension String {
   func percentEncoded() -> String {
-    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*").invertedSet
+    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',* ").invertedSet
     return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
   }
 }

--- a/Tests/URITemplateExpansionTests.swift
+++ b/Tests/URITemplateExpansionTests.swift
@@ -72,4 +72,10 @@ class URITemplateExpansionTests: XCTestCase {
         let expanded = template.expand(["names": ["Kyle", "Maxine"]])
         XCTAssertEqual(expanded, ".Kyle.Maxine")
     }
+	
+	func testURLEncodedSpaces() {
+		let template = URITemplate(template:"http://www.host.com/endpoint{?postal}")
+		let expanded = template.expand(["postal": "V3N 2R2"])
+		XCTAssertEqual(expanded, "http://www.host.com/endpoint?postal=V3N%202R2")
+	}
 }


### PR DESCRIPTION
percentEncoded() method did not account for white space characters that need to be URL encoded. I added the white space character to the character set and a unit test demonstrating how it fixed the problem.