### PR TITLE
Changed URL encoding to conform to RFC 3986 specification

### DIFF
--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -259,8 +259,12 @@ extension NSRegularExpression {
 
 extension String {
   func percentEncoded() -> String {
-    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',* ").invertedSet
-    return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
+		// Percent encoding confirming to RFC3986
+		let unreserved = "-._~/?"
+		let allowedCharacters = NSMutableCharacterSet.alphanumericCharacterSet()
+		allowedCharacters.addCharactersInString(unreserved)
+		
+		return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
   }
 }
 

--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -259,7 +259,7 @@ extension NSRegularExpression {
 
 extension String {
   func percentEncoded() -> String {
-    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',*").invertedSet
+    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',* ").invertedSet
     return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
   }
 }

--- a/Tests/URITemplateExpansionTests.swift
+++ b/Tests/URITemplateExpansionTests.swift
@@ -72,4 +72,10 @@ class URITemplateExpansionTests: XCTestCase {
         let expanded = template.expand(["names": ["Kyle", "Maxine"]])
         XCTAssertEqual(expanded, ".Kyle.Maxine")
     }
+	
+	func testURLEncodedSpaces() {
+		let template = URITemplate(template:"http://www.host.com/endpoint{?postal}")
+		let expanded = template.expand(["postal": "V3N 2R2"])
+		XCTAssertEqual(expanded, "http://www.host.com/endpoint?postal=V3N%202R2")
+	}
 }

--- a/Tests/URITemplateExpansionTests.swift
+++ b/Tests/URITemplateExpansionTests.swift
@@ -78,4 +78,16 @@ class URITemplateExpansionTests: XCTestCase {
 		let expanded = template.expand(["postal": "V3N 2R2"])
 		XCTAssertEqual(expanded, "http://www.host.com/endpoint?postal=V3N%202R2")
 	}
+	
+	func testURLEncodedQuotes() {
+		let template = URITemplate(template:"http://www.host.com/endpoint{?test}")
+		let expanded = template.expand(["test": "\"V3N\""])
+		XCTAssertEqual(expanded, "http://www.host.com/endpoint?test=%22V3N%22")
+	}
+	
+	func testURLEncodedCarrot() {
+		let template = URITemplate(template:"http://www.host.com/endpoint{?test}")
+		let expanded = template.expand(["test": "V3N^2R2"])
+		XCTAssertEqual(expanded, "http://www.host.com/endpoint?test=V3N%5E2R2")
+	}
 }


### PR DESCRIPTION
Added a couple more unit tests that involved percent encoding of the " and ^ characters which fails.

Used the solution from http://useyourloaf.com/blog/how-to-percent-encode-a-url-string/ to have the percentEncoded() method conform to RFC 3986.