### PR TITLE
Changed URL encoding to conform to RFC 3986 specification

### DIFF
--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -259,7 +259,11 @@ extension NSRegularExpression {
 
 extension String {
   func percentEncoded() -> String {
-    let allowedCharacters = NSCharacterSet(charactersInString: ":/?&=;+!@#$()',* ").invertedSet
+    // Percent encoding confirming to RFC3986
+    let unreserved = "-._~/?"
+    let allowedCharacters = NSMutableCharacterSet.alphanumericCharacterSet()
+    allowedCharacters.addCharactersInString(unreserved)
+		
     return stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
   }
 }

--- a/Tests/URITemplateCases.swift
+++ b/Tests/URITemplateCases.swift
@@ -79,7 +79,7 @@ class URITemplateCasesTests : DynamicTestCase {
     let imp = imp_implementationWithBlock(unsafeBitCast(block, AnyObject.self))
     let selectorName = name.stringByReplacingOccurrencesOfString(" ", withString: "_", options: NSStringCompareOptions(rawValue: 0), range: nil)
     let selector = Selector(selectorName)
-    let method = class_getInstanceMethod(self, "example") // No @encode in swift, creating a dummy method to get encoding
+    let method = class_getInstanceMethod(self, #selector(URITemplateCasesTests.example)) // No @encode in swift, creating a dummy method to get encoding
     let types = method_getTypeEncoding(method)
     let added = class_addMethod(self, selector, imp, types)
     assert(added, "Failed to add `\(name)` as `\(selector)`")

--- a/Tests/URITemplateExpansionTests.swift
+++ b/Tests/URITemplateExpansionTests.swift
@@ -72,10 +72,22 @@ class URITemplateExpansionTests: XCTestCase {
     let expanded = template.expand(["names": ["Kyle", "Maxine"]])
     XCTAssertEqual(expanded, ".Kyle.Maxine")
   }
-
+	
   func testURLEncodedSpaces() {
     let template = URITemplate(template:"{?postal}")
     let expanded = template.expand(["postal": "V3N 2R2"])
     XCTAssertEqual(expanded, "?postal=V3N%202R2")
+  }
+	
+  func testURLEncodedQuotes() {
+    let template = URITemplate(template:"{?test}")
+    let expanded = template.expand(["test": "\"V3N\""])
+    XCTAssertEqual(expanded, "?test=%22V3N%22")
+  }
+	
+  func testURLEncodedCarrot() {
+    let template = URITemplate(template:"{?test}")
+    let expanded = template.expand(["test": "V3N^2R2"])
+    XCTAssertEqual(expanded, "?test=V3N%5E2R2")
   }
 }


### PR DESCRIPTION
Added a couple more unit tests that involved percent encoding of the " and ^ characters which fails.

Used the solution from http://useyourloaf.com/blog/how-to-percent-encode-a-url-string/ to have the percentEncoded() method conform to RFC 3986.

Fixed Swift 3.0 warning about selector usage.