### PR TITLE
remove invalid submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Tests/Cases"]
-	path = Tests/Cases
-	url = https://github.com/uri-templates/uritemplate-test
 [submodule "Tests/URITemplateTests/Cases"]
 	path = Tests/URITemplateTests/Cases
 	url = https://github.com/uri-templates/uritemplate-test


### PR DESCRIPTION
as part of
https://github.com/kylef/URITemplate.swift/commit/8cf2b3cf5612cde716af7225aa04da6f0c45fe7
the test cases were moved to a new path `Tests/URITemplateTests/Cases`.
This submodule entry already exists. Only the old path needs to be
removed