### PR TITLE
fix: substring deprecations swift 4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
 import PackageDescription
 
-
 let package = Package(
   name: "URITemplate",
   dependencies: [
     .Package(url: "https://github.com/kylef/Spectre", majorVersion: 0, minor: 7),
     .Package(url: "https://github.com/kylef/PathKit", majorVersion: 0, minor: 7),
-  ]
+  ],
+  swiftLanguageVersions: [3, 4]
 )


### PR DESCRIPTION
Reason:
Swift 4 Strings will embrace subscript mechanisms for strings and marks `substring`-methods as deprecated.
`expression -> String` was added to remove ambiguity introduced by `#if #else #ifend`.

Package didn't really support to build and test with swift 4. 
If you want to test it, go on current head (6f71c64956e90adffe4123fb50f9f0f1d39df7ca) and set `swiftlanguageversions: [4]` to see the deprecations.