### PR TITLE
Conform to Swift's `Codable` protocol

### DIFF
--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -11,7 +11,7 @@ import Foundation
 // MARK: URITemplate
 
 /// A data structure to represent an RFC6570 URI template.
-public struct URITemplate : CustomStringConvertible, Equatable, Hashable, ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral {
+public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Codable, ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral {
   /// The underlying URI template
   public let template:String
 
@@ -55,6 +55,15 @@ public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Expres
 
   public init(stringLiteral value: StringLiteralType) {
     template = value
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.template = try decoder.singleValueContainer().decode(String.self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(template)
   }
 
   /// Returns a description of the URITemplate

--- a/Sources/URITemplate.swift
+++ b/Sources/URITemplate.swift
@@ -11,7 +11,7 @@ import Foundation
 // MARK: URITemplate
 
 /// A data structure to represent an RFC6570 URI template.
-public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Codable, ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral {
+public struct URITemplate : CustomStringConvertible, Equatable, Hashable, ExpressibleByStringLiteral, ExpressibleByExtendedGraphemeClusterLiteral, ExpressibleByUnicodeScalarLiteral {
   /// The underlying URI template
   public let template:String
 
@@ -57,14 +57,11 @@ public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Codabl
     template = value
   }
 
+#if swift(>=4.0)
   public init(from decoder: Decoder) throws {
     self.template = try decoder.singleValueContainer().decode(String.self)
   }
-
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-    try container.encode(template)
-  }
+#endif
 
   /// Returns a description of the URITemplate
   public var description: String {
@@ -273,6 +270,15 @@ public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Codabl
     return nil
   }
 }
+
+#if swift(>=4.0)
+extension URITemplate: Codable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(template)
+  }
+}
+#endif
 
 /// Determine if two URITemplate's are equivalent
 public func ==(lhs:URITemplate, rhs:URITemplate) -> Bool {

--- a/Tests/URITemplateTests/XCTest.swift
+++ b/Tests/URITemplateTests/XCTest.swift
@@ -30,6 +30,42 @@ public func testURITemplate() {
       }
     }
 
+    #if swift(>=4.0)
+    $0.describe("Codable") {
+      $0.it("decodes from a JSON representation") {
+        // JSON adapted from https://api.github.com
+        let jsonWithTemplates = """
+        {
+          "code_search_url": "https://api.github.com/search/code?q={query}{&page,per_page,sort,order}",
+          "commit_search_url": "https://api.github.com/search/commits?q={query}{&page,per_page,sort,order}",
+          "issue_search_url": "https://api.github.com/search/issues?q={query}{&page,per_page,sort,order}",
+          "repository_search_url": "https://api.github.com/search/repositories?q={query}{&page,per_page,sort,order}",
+          "user_search_url": "https://api.github.com/search/users?q={query}{&page,per_page,sort,order}"
+        }
+        """.data(using: .utf8)!
+
+        let jsonDecoder = JSONDecoder()
+        let templateDictionary = try jsonDecoder.decode([String: URITemplate].self, from: jsonWithTemplates)
+
+        try expect(templateDictionary["commit_search_url"]) == URITemplate(template: "https://api.github.com/search/commits?q={query}{&page,per_page,sort,order}")
+      }
+
+      $0.it("encodes and decodes without any loss of information") {
+        let templates = [
+          "search": URITemplate(template: "https://example.com/search?q{query}{&page,per_page}"),
+          "user": URITemplate(template: "https://example.com/users/{user_id}")
+        ]
+        let plistEncoder = PropertyListEncoder()
+        let plistDecoder = PropertyListDecoder()
+
+        let data = try plistEncoder.encode(templates)
+        let decodedTemplates = try plistDecoder.decode([String: URITemplate].self, from: data)
+
+        try expect(decodedTemplates) == templates
+      }
+    }
+    #endif
+
     $0.it("has a hashValue") {
       let template1 = URITemplate(template:"{scheme}://{hostname}/")
       let template2 = URITemplate(template:"{scheme}://{hostname}/")
@@ -42,41 +78,6 @@ public func testURITemplate() {
 
       try expect(literalTemplate) == template
     }
-
-#if swift(>=4.0)
-    $0.it("can be decoded from a JSON representation") {
-      // JSON adapted from https://api.github.com
-      let jsonWithTemplates = """
-      {
-        "code_search_url": "https://api.github.com/search/code?q={query}{&page,per_page,sort,order}",
-        "commit_search_url": "https://api.github.com/search/commits?q={query}{&page,per_page,sort,order}",
-        "issue_search_url": "https://api.github.com/search/issues?q={query}{&page,per_page,sort,order}",
-        "repository_search_url": "https://api.github.com/search/repositories?q={query}{&page,per_page,sort,order}",
-        "user_search_url": "https://api.github.com/search/users?q={query}{&page,per_page,sort,order}"
-      }
-      """.data(using: .utf8)!
-
-      let jsonDecoder = JSONDecoder()
-      let templateDictionary = try? jsonDecoder.decode([String: URITemplate].self, from: jsonWithTemplates)
-
-      try expect(templateDictionary != nil).to.beTrue()
-      try expect(templateDictionary!["commit_search_url"]) == URITemplate(template: "https://api.github.com/search/commits?q={query}{&page,per_page,sort,order}")
-    }
-
-    $0.it("can be encoded to and decoded from a property list") {
-      let templates = [
-        "search": URITemplate(template: "https://example.com/search?q{query}{&page,per_page}"),
-        "user": URITemplate(template: "https://example.com/users/{user_id}")
-      ]
-      let plistEncoder = PropertyListEncoder()
-      let data = try plistEncoder.encode(templates)
-
-      let plistDecoder = PropertyListDecoder()
-      let decodedTemplates = try plistDecoder.decode([String: URITemplate].self, from: data)
-
-      try expect(decodedTemplates) == templates
-    }
-#endif
 
     $0.describe("expansion", closure: testExpansion)
     $0.describe("variables", closure: testVariables)


### PR DESCRIPTION
This PR adds support for the `Codable` protocol added in Swift 4, allowing a string value to be decoded into a `URITemplate`. I had to take the somewhat unconventional approach of defining the `Init(from decoder:)` initialiser in the main struct definition, while declaring conformance to `Codable` in an extension to maintain support for Swift 3.x.