### PR TITLE
Use hasher for Hashable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url:"https://github.com/kylef/PathKit.git", .upToNextMinor(from:"1.0.0")),
-    .package(url:"https://github.com/kylef/Spectre.git", .upToNextPatch(from:"0.9.0"))
+    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.9.0"))
   ],
   targets: [
     .target(name: "URITemplate", dependencies: [], path: "Sources"),

--- a/Sources/URITemplate/URITemplate.swift
+++ b/Sources/URITemplate/URITemplate.swift
@@ -68,9 +68,15 @@ public struct URITemplate : CustomStringConvertible, Equatable, Hashable, Expres
     return template
   }
 
+#if swift(>=4.2)
+  public func hash(into hasher: inout Hasher) {
+    template.hash(into: &hasher)
+  }
+#else
   public var hashValue: Int {
     return template.hashValue
   }
+#endif
 
   /// Returns the set of keywords in the URI Template
   public var variables: [String] {


### PR DESCRIPTION
From Swift4.2, `hash(into hasher:Hasher)` has implemented and `hashValue` is now deprecated.